### PR TITLE
ci: run verify-completions.sh on every PR

### DIFF
--- a/.github/workflows/verify-completions.yml
+++ b/.github/workflows/verify-completions.yml
@@ -1,0 +1,28 @@
+name: Verify Completions
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  verify:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y expect zsh
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install expect zsh
+
+      - name: Run verify-completions.sh
+        run: ./scripts/verify-completions.sh


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/verify-completions.yml` that runs `scripts/verify-completions.sh` on every PR and on pushes to `main`.
- Matrix runs on `ubuntu-latest` and `macos-latest` so platform-specific regressions (like the BSD-vs-GNU `stat` bug fixed in #113) get caught before merge.
- Uses the existing verification script — no new test infrastructure to maintain.

## Test plan
- [ ] Workflow triggers on this PR and both jobs (Ubuntu + macOS) pass.
- [ ] Workflow appears as a required check option in repo branch protection settings.

https://claude.ai/code/session_01Hox3rwXhfBD3MUpytcQDqE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hox3rwXhfBD3MUpytcQDqE)_