### PR TITLE
test: split verify-completions per feature and cover _claude_session_ids

### DIFF
--- a/.github/workflows/update-completions.yml
+++ b/.github/workflows/update-completions.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y expect zsh
+        run: sudo apt-get update && sudo apt-get install -y expect zsh jq
 
       - name: Install Claude CLI
         run: curl -fsSL https://claude.ai/install.sh | bash

--- a/.github/workflows/verify-completions.yml
+++ b/.github/workflows/verify-completions.yml
@@ -18,11 +18,11 @@ jobs:
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y expect zsh
+        run: sudo apt-get update && sudo apt-get install -y expect zsh jq
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
-        run: brew install expect zsh
+        run: brew install expect zsh jq
 
       - name: Run verify-completions.sh
         run: ./scripts/verify-completions.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,12 +25,18 @@ The `_claude` script uses a case statement with early returns to route between s
 
 ## Development Notes
 
-No build system, tests, or linting—pure zsh scripts only.
+No build system or linting—pure zsh scripts only.
 
-To test changes:
+To test changes manually:
 1. Source the plugin: `source zsh-claudecode-completion.plugin.zsh`
 2. Reload completions: `autoload -Uz compinit && compinit`
 3. Test with: `claude <TAB>`
+
+Automated tests live under `scripts/tests/` and are driven by
+`scripts/verify-completions.sh`. Each `test-*.sh` covers one feature
+(syntax, global flags, mcp subcommand, `_claude_session_ids`). The runner
+also accepts a single test name: `./scripts/verify-completions.sh
+test-session-ids`. Requires `zsh`, `expect`, and `jq`.
 
 ## Known Patterns
 

--- a/scripts/tests/lib/common.sh
+++ b/scripts/tests/lib/common.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+#
+# Shared helpers for completion verification tests.
+#
+# Each test script under scripts/tests/test-*.sh sources this file, then
+# uses the helpers below to drive an interactive zsh under expect.
+
+# Resolve the repo root regardless of where the test was invoked from.
+COMMON_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$COMMON_LIB_DIR/../../.." && pwd)"
+COMPLETION_FILE="$REPO_ROOT/_claude"
+
+# Test name for log prefixes — set by each test file.
+: "${TEST_NAME:=$(basename "${0##*/}" .sh)}"
+
+log()  { printf '  [%s] %s\n' "$TEST_NAME" "$*"; }
+fail() { printf '\n[%s] FAIL: %s\n' "$TEST_NAME" "$*" >&2; exit 1; }
+pass() { printf '[%s] PASS%s\n'    "$TEST_NAME" "${1:+: $1}"; exit 0; }
+
+require_dep() {
+    command -v "$1" >/dev/null 2>&1 || fail "required dependency '$1' is not installed"
+}
+
+require_common_deps() {
+    require_dep zsh
+    require_dep expect
+    [[ -f "$COMPLETION_FILE" ]] || fail "completion file not found: $COMPLETION_FILE"
+}
+
+# Create a temporary HOME with a minimal .zshrc that loads the completion.
+# Caller is responsible for cleaning up.
+#
+#   home=$(make_test_home)
+#   trap 'rm -rf "$home"' EXIT
+make_test_home() {
+    local home
+    home=$(mktemp -d)
+    cat > "$home/.zshrc" <<ZSHRC
+fpath=($REPO_ROOT \$fpath)
+autoload -Uz compinit && compinit -u -d /dev/null
+autoload -Uz _claude && compdef _claude claude
+setopt AUTO_LIST NO_BEEP
+PS1='TEST> '
+ZSHRC
+    printf '%s\n' "$home"
+}
+
+# Drive zsh through expect: spawn with HOME=$home and CWD=$start_dir,
+# source the test rc, send $send_keys, wait briefly for completion output,
+# then exit cleanly. Everything zsh wrote to the tty is echoed to stdout
+# so the caller can grep it.
+#
+# Usage: output=$(run_completion "$home" "$start_dir" 'claude -r \t' [extra_env])
+# extra_env is an optional Tcl line, e.g.  'set env(CLAUDE_COMPLETION_SESSION_LIMIT) "1"'
+run_completion() {
+    local home="$1" start_dir="$2" send_keys="$3" extra_env="${4:-}"
+    local output_file="$home/expect-output.txt"
+
+    # The heredoc is unquoted so bash variables ($home, $send_keys, $start_dir,
+    # $extra_env) expand. Tcl-level `$` escapes use `\$`, which bash collapses
+    # to `$` before expect sees it. This mirrors the pattern in the previous
+    # monolithic verify-completions.sh.
+    expect <<EXPECT_SCRIPT > "$output_file" 2>&1
+set timeout 15
+set env(HOME) "$home"
+$extra_env
+cd "$start_dir"
+spawn zsh -f
+
+expect {
+    -re {%|>|\$} {}
+    timeout { puts "TIMEOUT_INITIAL"; exit 1 }
+    eof { puts "EOF_INITIAL"; exit 1 }
+}
+
+send "source $home/.zshrc\r"
+expect {
+    "TEST>" {}
+    -re "insecure directories" { send "y\r"; exp_continue }
+    timeout { puts "TIMEOUT_RC"; exit 1 }
+    eof { puts "EOF_RC"; exit 1 }
+}
+
+send "$send_keys"
+sleep 1
+
+expect {
+    -re "invalid option definition" { puts "ERROR_INVALID_OPTION" }
+    -re "_arguments:.*:.*:" { puts "ERROR_ARGUMENTS" }
+    -re "TEST>" {}
+    timeout {}
+}
+
+# Clear the half-typed line, then exit cleanly.
+send "\003"
+sleep 0.1
+send "exit\r"
+expect eof
+puts "EXPECT_DONE"
+EXPECT_SCRIPT
+
+    local rc=$?
+    cat "$output_file"
+    return $rc
+}
+
+# Standard sanity checks for run_completion output.
+assert_no_completion_errors() {
+    local output="$1"
+    if grep -q "ERROR_INVALID_OPTION" <<< "$output"; then
+        printf '%s\n' "$output" >&2
+        fail "invalid option definition detected"
+    fi
+    if grep -q "ERROR_ARGUMENTS" <<< "$output"; then
+        printf '%s\n' "$output" >&2
+        fail "_arguments parsing error detected"
+    fi
+    if ! grep -q "EXPECT_DONE" <<< "$output"; then
+        printf '%s\n' "$output" >&2
+        fail "expect harness did not finish (timeout or zsh crash)"
+    fi
+}
+
+assert_contains() {
+    local needle="$1" output="$2" desc="${3:-output}"
+    if ! grep -q -- "$needle" <<< "$output"; then
+        printf '%s\n' "$output" >&2
+        fail "expected '$needle' to appear in $desc"
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1" output="$2" desc="${3:-output}"
+    if grep -q -- "$needle" <<< "$output"; then
+        printf '%s\n' "$output" >&2
+        fail "expected '$needle' to NOT appear in $desc"
+    fi
+}

--- a/scripts/tests/lib/common.sh
+++ b/scripts/tests/lib/common.sh
@@ -34,7 +34,12 @@ require_common_deps() {
 #   trap 'rm -rf "$home"' EXIT
 make_test_home() {
     local home
-    home=$(mktemp -d)
+    # Canonicalize the path so it matches what zsh's $PWD will report
+    # after `getcwd(2)` — on macOS /var is a symlink to /private/var, and
+    # `mktemp -d` returns the un-resolved /var/... form. If we used that
+    # raw, the path-mangling in _claude_session_ids would compare strings
+    # built from two different canonicalizations and never match.
+    home=$(cd "$(mktemp -d)" && pwd -P)
     cat > "$home/.zshrc" <<ZSHRC
 fpath=($REPO_ROOT \$fpath)
 autoload -Uz compinit && compinit -u -d /dev/null

--- a/scripts/tests/test-global-flags.sh
+++ b/scripts/tests/test-global-flags.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Interactive completion test for the global flag layer.
+# Tabs through `claude --` and confirms _arguments doesn't error out.
+
+set -e
+TEST_NAME=test-global-flags
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
+
+require_common_deps
+
+home=$(make_test_home)
+trap 'rm -rf "$home"' EXIT
+
+log "completing 'claude --<TAB>'"
+output=$(run_completion "$home" "$home" 'claude --\t')
+assert_no_completion_errors "$output"
+
+pass "global flag completion OK"

--- a/scripts/tests/test-mcp-subcommand.sh
+++ b/scripts/tests/test-mcp-subcommand.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Subcommand completion test. Catches issues with alias-expanded flags
+# appearing before the subcommand and with the per-subcommand _arguments
+# blocks (e.g. `claude mcp <TAB>`).
+
+set -e
+TEST_NAME=test-mcp-subcommand
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
+
+require_common_deps
+
+home=$(make_test_home)
+trap 'rm -rf "$home"' EXIT
+
+log "completing 'claude mcp <TAB>'"
+output=$(run_completion "$home" "$home" 'claude mcp \t')
+assert_no_completion_errors "$output"
+
+pass "mcp subcommand completion OK"

--- a/scripts/tests/test-session-ids.sh
+++ b/scripts/tests/test-session-ids.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+#
+# Coverage for the _claude_session_ids completer (claude -r / --resume).
+#
+# Builds a fake $HOME/.claude/projects/<mangled-PWD>/ tree, then asserts that:
+#   1. Indexed sessions (sessions-index.json) appear in the completion list.
+#   2. Unindexed JSONL sessions appear too, with branch + summary parsed.
+#   3. The originalPath fallback matches when the mangled directory is missing.
+#   4. CLAUDE_COMPLETION_SESSION_LIMIT caps the displayed count.
+#
+# The fixture path is intentionally placed under a directory whose name
+# contains a `.` so we also exercise the dot-mangling branch (commit history
+# shows that branch was previously broken).
+
+set -e
+TEST_NAME=test-session-ids
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
+
+require_common_deps
+require_dep jq
+
+# ---------------------------------------------------------------------------
+# Fixture builder
+# ---------------------------------------------------------------------------
+# Args:
+#   $1 home      — fake HOME root
+#   $2 work_dir  — directory the user is "in" when they hit TAB
+#   $3 mode      — "matching" | "fallback"
+#       matching: place the project dir at the mangled-PWD path
+#       fallback: place it under a different dir, but with originalPath set
+#                 so the function's fallback search picks it up
+build_fixture() {
+    local home="$1" work_dir="$2" mode="$3"
+    mkdir -p "$work_dir"
+
+    local mangled="${work_dir//\//-}"
+    mangled="${mangled//./-}"
+    local proj_dir
+    if [[ "$mode" == "matching" ]]; then
+        proj_dir="$home/.claude/projects/$mangled"
+    else
+        proj_dir="$home/.claude/projects/-some-other-name"
+    fi
+    mkdir -p "$proj_dir"
+
+    # An indexed session — newest, so it sorts first.
+    cat > "$proj_dir/sessions-index.json" <<JSON
+{
+  "originalPath": "$work_dir",
+  "entries": [
+    {
+      "sessionId": "aaaaaaaa-1111-2222-3333-aaaaaaaaaaaa",
+      "modified": "2026-05-09T12:00:00",
+      "gitBranch": "main",
+      "summary": "indexed session label"
+    }
+  ]
+}
+JSON
+
+    # A JSONL session not in the index — older, so it appears after the
+    # indexed one (verifies pass-2 jq parsing, mtime sort).
+    local uuid_jsonl="bbbbbbbb-1111-2222-3333-bbbbbbbbbbbb"
+    cat > "$proj_dir/$uuid_jsonl.jsonl" <<JSONL
+{"type":"user","gitBranch":"feature","message":{"content":"jsonl session prompt"}}
+JSONL
+    touch -d "2026-05-08 10:00:00" "$proj_dir/$uuid_jsonl.jsonl"
+
+    # A JSONL session that contains ONLY a <command-*> wrapped prompt — the
+    # completer should filter this out (claude --resume rejects it).
+    local uuid_filtered="cccccccc-1111-2222-3333-cccccccccccc"
+    cat > "$proj_dir/$uuid_filtered.jsonl" <<JSONL
+{"type":"user","gitBranch":"main","message":{"content":"<command-stdout>boring</command-stdout>"}}
+JSONL
+    touch -d "2026-05-07 10:00:00" "$proj_dir/$uuid_filtered.jsonl"
+
+    printf '%s\n' "$proj_dir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: matching mangled path — basic case
+# ---------------------------------------------------------------------------
+home=$(make_test_home)
+trap 'rm -rf "$home"' EXIT
+
+# Use a subdirectory whose name contains a dot, to exercise dot-mangling.
+work_dir="$home/proj.example/work"
+build_fixture "$home" "$work_dir" "matching" >/dev/null
+
+log "case 1: indexed + jsonl sessions, mangled path matches"
+output=$(run_completion "$home" "$work_dir" 'claude -r \t')
+assert_no_completion_errors "$output"
+assert_contains "aaaaaaaa" "$output" "indexed session UUID prefix"
+assert_contains "indexed session label" "$output" "indexed session summary"
+assert_contains "main"     "$output" "indexed session branch"
+assert_contains "bbbbbbbb" "$output" "jsonl session UUID prefix"
+assert_contains "feature"  "$output" "jsonl session branch"
+assert_contains "jsonl session prompt" "$output" "jsonl session summary"
+# Filtered <command-*> session must not show up.
+assert_not_contains "cccccccc" "$output" "filtered command-only session"
+
+# ---------------------------------------------------------------------------
+# Test 2: fallback via sessions-index.json originalPath
+# ---------------------------------------------------------------------------
+rm -rf "$home/.claude"
+work_dir2="$home/fallback.dir/work"
+build_fixture "$home" "$work_dir2" "fallback" >/dev/null
+
+log "case 2: mangled dir absent, originalPath fallback"
+output=$(run_completion "$home" "$work_dir2" 'claude -r \t')
+assert_no_completion_errors "$output"
+assert_contains "aaaaaaaa" "$output" "fallback-located indexed UUID"
+assert_contains "indexed session label" "$output" "fallback-located summary"
+
+# ---------------------------------------------------------------------------
+# Test 3: CLAUDE_COMPLETION_SESSION_LIMIT caps the listed sessions
+# ---------------------------------------------------------------------------
+rm -rf "$home/.claude"
+work_dir3="$home/cap.test/work"
+build_fixture "$home" "$work_dir3" "matching" >/dev/null
+
+log "case 3: CLAUDE_COMPLETION_SESSION_LIMIT=1 caps output"
+output=$(run_completion "$home" "$work_dir3" 'claude -r \t' \
+    'set env(CLAUDE_COMPLETION_SESSION_LIMIT) "1"')
+assert_no_completion_errors "$output"
+# Newest is the indexed session (2026-05-09); the JSONL one is older and
+# should be capped out.
+assert_contains "aaaaaaaa" "$output" "newest session under cap"
+assert_not_contains "bbbbbbbb" "$output" "older session capped out"
+
+pass "session id auto-suggestion OK"

--- a/scripts/tests/test-session-ids.sh
+++ b/scripts/tests/test-session-ids.sh
@@ -64,7 +64,8 @@ JSON
     cat > "$proj_dir/$uuid_jsonl.jsonl" <<JSONL
 {"type":"user","gitBranch":"feature","message":{"content":"jsonl session prompt"}}
 JSONL
-    touch -d "2026-05-08 10:00:00" "$proj_dir/$uuid_jsonl.jsonl"
+    # ISO-8601 with T separator — BSD touch on macOS rejects the space form.
+    touch -d "2026-05-08T10:00:00" "$proj_dir/$uuid_jsonl.jsonl"
 
     # A JSONL session that contains ONLY a <command-*> wrapped prompt — the
     # completer should filter this out (claude --resume rejects it).
@@ -72,7 +73,7 @@ JSONL
     cat > "$proj_dir/$uuid_filtered.jsonl" <<JSONL
 {"type":"user","gitBranch":"main","message":{"content":"<command-stdout>boring</command-stdout>"}}
 JSONL
-    touch -d "2026-05-07 10:00:00" "$proj_dir/$uuid_filtered.jsonl"
+    touch -d "2026-05-07T10:00:00" "$proj_dir/$uuid_filtered.jsonl"
 
     printf '%s\n' "$proj_dir"
 }

--- a/scripts/tests/test-syntax.sh
+++ b/scripts/tests/test-syntax.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Static syntax check: confirm `zsh -n _claude` parses without errors.
+# This catches typos, unterminated strings, and other parse-time issues
+# without needing an interactive session.
+
+set -e
+TEST_NAME=test-syntax
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
+
+require_dep zsh
+[[ -f "$COMPLETION_FILE" ]] || fail "completion file not found: $COMPLETION_FILE"
+
+log "running zsh -n on $COMPLETION_FILE"
+output=$(zsh -n "$COMPLETION_FILE" 2>&1) || {
+    printf '%s\n' "$output" >&2
+    fail "zsh -n reported syntax errors"
+}
+
+pass "static syntax OK"

--- a/scripts/verify-completions.sh
+++ b/scripts/verify-completions.sh
@@ -1,263 +1,79 @@
 #!/bin/bash
 #
-# Verification script for zsh completion script
+# Test runner for the _claude completion script.
 #
-# Tests that the _claude completion script can be loaded and executed
-# without errors. Uses expect to simulate tab completion in an interactive
-# zsh session, which catches _arguments parsing errors that static checks miss.
+# Discovers and executes every scripts/tests/test-*.sh file, then prints a
+# summary. Each subtest is self-contained: it sources lib/common.sh, builds
+# its own fixture, drives zsh through expect, and exits 0/non-zero.
+#
+# Usage:
+#   ./scripts/verify-completions.sh                  # run everything
+#   ./scripts/verify-completions.sh test-session-ids # run a single test
 #
 # Exit codes:
-#   0 - Verification passed
-#   1 - Verification failed (completion errors detected)
+#   0 - all tests passed
+#   1 - one or more tests failed
 
-set -e
+set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-COMPLETION_FILE="$REPO_ROOT/_claude"
+TEST_DIR="$SCRIPT_DIR/tests"
 
-# Check dependencies
-if ! command -v expect &> /dev/null; then
-    echo "Error: 'expect' is required but not installed"
-    echo "Install with: brew install expect (macOS) or apt-get install expect (Linux)"
+if [[ ! -d "$TEST_DIR" ]]; then
+    echo "Error: test directory not found: $TEST_DIR" >&2
     exit 1
 fi
 
-if ! command -v zsh &> /dev/null; then
-    echo "Error: 'zsh' is required but not installed"
+# Build the list of tests to run.
+declare -a tests
+if (( $# > 0 )); then
+    for arg in "$@"; do
+        # Accept both bare names and full paths.
+        if [[ -f "$TEST_DIR/$arg.sh" ]]; then
+            tests+=("$TEST_DIR/$arg.sh")
+        elif [[ -f "$arg" ]]; then
+            tests+=("$arg")
+        else
+            echo "Error: test not found: $arg" >&2
+            exit 1
+        fi
+    done
+else
+    while IFS= read -r -d '' f; do
+        tests+=("$f")
+    done < <(find "$TEST_DIR" -maxdepth 1 -name 'test-*.sh' -type f -print0 | sort -z)
+fi
+
+if (( ${#tests[@]} == 0 )); then
+    echo "Error: no test files found under $TEST_DIR" >&2
     exit 1
 fi
 
-if [[ ! -f "$COMPLETION_FILE" ]]; then
-    echo "Error: Completion file not found: $COMPLETION_FILE"
-    exit 1
-fi
+declare -i passed=0 failed=0
+declare -a failures
 
-echo "Verifying completion script: $COMPLETION_FILE"
+for t in "${tests[@]}"; do
+    name=$(basename "$t" .sh)
+    echo "=== $name ==="
+    if bash "$t"; then
+        passed+=1
+    else
+        failed+=1
+        failures+=("$name")
+    fi
+    echo
+done
 
-# Test 1: Static syntax check
-echo "  [1/3] Running static syntax check..."
-SYNTAX_OUTPUT=$(zsh -n "$COMPLETION_FILE" 2>&1) || {
-    echo ""
+echo "================================="
+echo "Tests passed: $passed   failed: $failed"
+if (( failed > 0 )); then
+    echo
+    echo "Failed tests:"
+    printf '  - %s\n' "${failures[@]}"
+    echo
     echo "VERIFICATION FAILED"
-    echo "==================="
-    echo "Static syntax check failed:"
-    echo "$SYNTAX_OUTPUT"
-    exit 1
-}
-
-# Test 2: Interactive completion test using expect
-echo "  [2/3] Testing interactive completion (global flags)..."
-
-# Create a temporary directory for our test zsh configuration
-TMPDIR=$(mktemp -d)
-trap "rm -rf $TMPDIR" EXIT
-
-# Create a minimal .zshrc that loads our completion
-cat > "$TMPDIR/.zshrc" << ZSHRC
-fpath=($REPO_ROOT \$fpath)
-autoload -Uz compinit && compinit -u -d /dev/null
-autoload -Uz _claude && compdef _claude claude
-PS1='TEST> '
-ZSHRC
-
-# Run expect to test completion
-OUTPUT_FILE="$TMPDIR/output.txt"
-ZSHRC_FILE="$TMPDIR/.zshrc"
-
-# Temporarily disable exit on error for expect
-set +e
-expect << EXPECT_SCRIPT > "$OUTPUT_FILE" 2>&1
-set timeout 10
-set env(HOME) "$TMPDIR"
-
-# Use zsh -f to skip ALL rc files (avoids system compinit prompts on Ubuntu)
-# Then manually source our test configuration
-spawn zsh -f
-
-# Wait for basic prompt
-expect {
-    -re {%|>|\$} {}
-    timeout { puts "TIMEOUT: waiting for initial prompt"; exit 1 }
-    eof { puts "EOF: zsh exited unexpectedly"; exit 1 }
-}
-
-# Source our test configuration
-send "source $ZSHRC_FILE\r"
-
-# Wait for our custom prompt
-expect {
-    "TEST>" {}
-    -re "insecure directories" {
-        # Handle compinit security prompt if it appears
-        send "y\r"
-        exp_continue
-    }
-    timeout { puts "TIMEOUT: waiting for TEST> prompt"; exit 1 }
-    eof { puts "EOF: zsh exited unexpectedly"; exit 1 }
-}
-
-# Test: Trigger completion for 'claude --'
-send "claude --\t"
-sleep 0.5
-
-expect {
-    -re "invalid option definition" {
-        puts "ERROR: invalid option definition detected"
-        exit 1
-    }
-    -re "_arguments:.*:.*:" {
-        puts "ERROR: _arguments error detected"
-        exit 1
-    }
-    "TEST>" {}
-    timeout {}
-}
-
-send "exit\r"
-expect eof
-
-puts "COMPLETION_TEST_PASSED"
-exit 0
-EXPECT_SCRIPT
-
-EXPECT_EXIT=$?
-set -e
-
-# Check results
-if [[ $EXPECT_EXIT -ne 0 ]]; then
-    echo ""
-    echo "VERIFICATION FAILED"
-    echo "==================="
-    echo "Interactive completion test failed"
-    echo ""
-    echo "Output:"
-    cat "$OUTPUT_FILE"
     exit 1
 fi
 
-if grep -q "invalid option definition" "$OUTPUT_FILE"; then
-    echo ""
-    echo "VERIFICATION FAILED"
-    echo "==================="
-    echo "Invalid option definition error detected:"
-    echo ""
-    cat "$OUTPUT_FILE"
-    exit 1
-fi
-
-if grep -q "ERROR:" "$OUTPUT_FILE"; then
-    echo ""
-    echo "VERIFICATION FAILED"
-    echo "==================="
-    echo "Completion errors detected:"
-    echo ""
-    cat "$OUTPUT_FILE"
-    exit 1
-fi
-
-if ! grep -q "COMPLETION_TEST_PASSED" "$OUTPUT_FILE"; then
-    echo ""
-    echo "VERIFICATION FAILED"
-    echo "==================="
-    echo "Completion test did not complete successfully"
-    echo ""
-    echo "Output:"
-    cat "$OUTPUT_FILE"
-    exit 1
-fi
-
-# Test 3: Subcommand completion test (catches issues with alias-expanded flags before subcommands)
-echo "  [3/3] Testing subcommand completion..."
-
-OUTPUT_FILE2="$TMPDIR/output2.txt"
-
-set +e
-expect << EXPECT_SCRIPT > "$OUTPUT_FILE2" 2>&1
-set timeout 10
-set env(HOME) "$TMPDIR"
-
-spawn zsh -f
-
-expect {
-    -re {%|>|\$} {}
-    timeout { puts "TIMEOUT: waiting for initial prompt"; exit 1 }
-    eof { puts "EOF: zsh exited unexpectedly"; exit 1 }
-}
-
-send "source $ZSHRC_FILE\r"
-
-expect {
-    "TEST>" {}
-    -re "insecure directories" {
-        send "y\r"
-        exp_continue
-    }
-    timeout { puts "TIMEOUT: waiting for TEST> prompt"; exit 1 }
-    eof { puts "EOF: zsh exited unexpectedly"; exit 1 }
-}
-
-# Test: Trigger completion for 'claude mcp ' (subcommand)
-send "claude mcp \t"
-sleep 0.5
-
-expect {
-    -re "invalid option definition" {
-        puts "ERROR: invalid option definition detected in subcommand"
-        exit 1
-    }
-    -re "_arguments:.*:.*:" {
-        puts "ERROR: _arguments error detected in subcommand"
-        exit 1
-    }
-    "TEST>" {}
-    timeout {}
-}
-
-send "exit\r"
-expect eof
-
-puts "SUBCMD_TEST_PASSED"
-exit 0
-EXPECT_SCRIPT
-
-EXPECT_EXIT2=$?
-set -e
-
-if [[ $EXPECT_EXIT2 -ne 0 ]]; then
-    echo ""
-    echo "VERIFICATION FAILED"
-    echo "==================="
-    echo "Subcommand completion test failed"
-    echo ""
-    echo "Output:"
-    cat "$OUTPUT_FILE2"
-    exit 1
-fi
-
-if grep -q "ERROR:" "$OUTPUT_FILE2"; then
-    echo ""
-    echo "VERIFICATION FAILED"
-    echo "==================="
-    echo "Subcommand completion errors detected:"
-    echo ""
-    cat "$OUTPUT_FILE2"
-    exit 1
-fi
-
-if ! grep -q "SUBCMD_TEST_PASSED" "$OUTPUT_FILE2"; then
-    echo ""
-    echo "VERIFICATION FAILED"
-    echo "==================="
-    echo "Subcommand completion test did not complete successfully"
-    echo ""
-    echo "Output:"
-    cat "$OUTPUT_FILE2"
-    exit 1
-fi
-
-echo ""
 echo "VERIFICATION PASSED"
-echo "==================="
-echo "Completion script validated successfully"
 exit 0


### PR DESCRIPTION
## Summary

The previous `scripts/verify-completions.sh` ran three checks inline (`zsh -n`, `claude --<TAB>`, `claude mcp <TAB>`) and never invoked `_claude_session_ids` — the most logic-heavy part of `_claude` (PWD mangling, `originalPath` fallback, indexed/JSONL two-pass enumeration, `CLAUDE_COMPLETION_SESSION_LIMIT` cap, `<command-*>` filtering were all untested).

This PR refactors the script into a runner + per-feature test files and adds coverage for the session-id completer.

### Refactor

- `scripts/verify-completions.sh` becomes a discovery runner (`./scripts/verify-completions.sh` runs all, `./scripts/verify-completions.sh test-session-ids` runs one).
- `scripts/tests/lib/common.sh` holds the shared expect/zsh harness (`make_test_home`, `run_completion`, `assert_*`).
- One file per feature under `scripts/tests/`:
  - `test-syntax.sh` — `zsh -n` parse check
  - `test-global-flags.sh` — `claude --<TAB>`
  - `test-mcp-subcommand.sh` — `claude mcp <TAB>`
  - `test-session-ids.sh` — three cases for `_claude_session_ids`

### Session-id coverage

`test-session-ids.sh` builds a fake `$HOME/.claude/projects/<mangled-PWD>/` tree (the work dir name contains a `.` to exercise the dot-mangling branch that regressed in commit ff451fe earlier this year), then asserts:

1. **Matching mangled path** — both an indexed session (`sessions-index.json`) and an unindexed JSONL session appear with the right branch/summary; a JSONL containing only `<command-*>` content is filtered out.
2. **Fallback** — when the mangled directory is absent, the function locates the project via `originalPath` in any `sessions-index.json` and still surfaces the session.
3. **Cap** — `CLAUDE_COMPLETION_SESSION_LIMIT=1` keeps only the newest entry.

Each fixture's JSON was validated against the completer's actual `jq` pipelines (line 59 and lines 123–137 of `_claude`) before commit.

### CI

Both workflows now also install `jq`, which the completer (and the new fixture builder) require.

## Test plan

- [ ] CI `Verify Completions` passes on Ubuntu and macOS
- [ ] `./scripts/verify-completions.sh` succeeds locally with `zsh`, `expect`, `jq` installed
- [ ] `./scripts/verify-completions.sh test-session-ids` runs only the session-id test
- [ ] All three session-id assertions exercise the documented branches (manual spot-check on the real `~/.claude/projects/` after install)

https://claude.ai/code/session_01XA9TfzJG2GngbC2b34fWB5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XA9TfzJG2GngbC2b34fWB5)_