### PR TITLE
feat: complete attach/logs/stop/kill/respawn/rm background-session commands

### DIFF
--- a/_claude
+++ b/_claude
@@ -154,6 +154,84 @@ _claude_session_ids() {
   _wanted session-ids expl 'session' compadd -V sessions -o nosort -d labels -a ids
 }
 
+# Background-session ID completer for `claude attach|logs|stop|kill|respawn|rm`.
+# Source of truth is the supervisor's roster at ~/.claude/daemon/roster.json,
+# which lists every live background session. Each id is then enriched with the
+# session's display name from ~/.claude/jobs/<id>/state.json so the completion
+# shows the user which session they're picking (the short id alone is opaque).
+# Honors CLAUDE_CONFIG_DIR per the docs (background sessions are stored there
+# instead of ~/.claude when set).
+_claude_background_session_ids() {
+  local config_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+  local roster="$config_dir/daemon/roster.json"
+  local jobs_dir="$config_dir/jobs"
+
+  local -a ids labels
+  local -a roster_ids
+  local id
+
+  if [[ -r "$roster" ]]; then
+    # roster.json shape isn't formally documented; be permissive about top-level
+    # array vs. object-with-list and about the id key name.
+    while IFS= read -r id; do
+      [[ -z "$id" || "$id" == "null" ]] && continue
+      roster_ids+=("$id")
+    done < <(jq -r '
+      def ids:
+        if type=="array" then .[]
+        elif type=="object" then (.sessions? // .jobs? // .entries? // empty) | .[]?
+        else empty end;
+      [ids | (.id? // .sessionId? // .shortId? // (if type=="string" then . else empty end))]
+      | .[] | select(. != null and . != "")
+    ' "$roster" 2>/dev/null)
+  fi
+
+  # Fallback: if roster is missing or empty (e.g. supervisor not running but
+  # state files still on disk), enumerate ~/.claude/jobs/* directly. Limited to
+  # entries that actually have a state.json so we don't surface stale dirs.
+  if (( ${#roster_ids} == 0 )) && [[ -d "$jobs_dir" ]]; then
+    local d
+    for d in "$jobs_dir"/*(N/); do
+      [[ -f "$d/state.json" ]] || continue
+      roster_ids+=("${d:t}")
+    done
+  fi
+
+  (( ${#roster_ids} == 0 )) && return 1
+
+  local state_file name state info
+  for id in "${roster_ids[@]}"; do
+    state_file="$jobs_dir/$id/state.json"
+    name=""
+    state=""
+    if [[ -r "$state_file" ]]; then
+      # Try several plausible field names — the state.json schema isn't pinned
+      # publicly, so we degrade gracefully if any one is missing.
+      info=$(jq -r '
+        [
+          (.name // .displayName // .title // .sessionName // .summary // .prompt // ""),
+          (.state // .status // .lifecycle // "")
+        ] | @tsv
+      ' "$state_file" 2>/dev/null)
+      name="${info%%$'\t'*}"
+      state="${info#*$'\t'}"
+    fi
+    ids+=("$id")
+    if [[ -n "$name" && -n "$state" ]]; then
+      labels+=("${id} [${state}] ${name}")
+    elif [[ -n "$name" ]]; then
+      labels+=("${id} ${name}")
+    elif [[ -n "$state" ]]; then
+      labels+=("${id} [${state}]")
+    else
+      labels+=("${id}")
+    fi
+  done
+
+  local expl
+  _wanted bg-session-ids expl 'background session' compadd -o nosort -d labels -a ids
+}
+
 # Offer a freshly-generated UUID for --session-id, which expects a NEW,
 # user-assigned session identifier (not an existing session to resume).
 local curcontext="$curcontext" state line
@@ -161,17 +239,23 @@ typeset -A opt_args
 
 local -a commands
 commands=(
-  'agents:Manage background and configured agents'
+  'agents:Open agent view (manage background sessions)'
+  'attach:Attach to a background session in this terminal'
   'auth:Manage authentication'
   'auto-mode:Inspect auto mode classifier configuration'
   'doctor:Check the health of your Claude Code auto-updater'
   'install:Install Claude Code native build. Use [target] to specify version (stable, latest, or specific version)'
+  'kill:Stop a background session (alias for stop)'
+  'logs:Print a background session'\''s recent output'
   'mcp:Configure and manage MCP servers'
   'plugin:Manage Claude Code plugins'
   'plugins:Manage Claude Code plugins'
   'project:Manage Claude Code project state'
+  'respawn:Restart a stopped background session with its conversation intact'
+  'rm:Remove a background session from the list'
   'setup-token:Set up a long-lived authentication token (requires Claude subscription)'
   'remote-control:Connect your local environment to claude.ai/code'
+  'stop:Stop a background session'
   'ultrareview:Run a cloud-hosted multi-agent code review of the current branch (or a PR number / base branch) and print the findings'
   'update:Check for updates and install if available'
   'upgrade:Check for updates and install if available'
@@ -231,7 +315,7 @@ marketplace_commands=(
 # This handles cases where flags appear before the subcommand (e.g., alias claude='claude --flag').
 local subcmd_pos=0
 local subcmd=""
-local -a known_commands=(agents auth auto-mode doctor install mcp plugin plugins project remote-control setup-token ultrareview update upgrade)
+local -a known_commands=(agents attach auth auto-mode doctor install kill logs mcp plugin plugins project remote-control respawn rm setup-token stop ultrareview update upgrade)
 local i
 for (( i=2; i <= ${#words}; i++ )); do
   # Skip flags and their values
@@ -254,6 +338,25 @@ case $subcmd in
     _arguments \
       '(-h --help)'{-h,--help}'[Display help for command]' \
       '--setting-sources[Comma-separated list of setting sources to load (user, project, local)]:sources:'
+    return
+    ;;
+  attach|logs|stop|kill|rm)
+    # The leading ':cmd:' placeholder accounts for the subcommand word
+    # already in $words — _arguments here is invoked as `claude`'s completer
+    # and counts positionals from $words[2], so position 1 = the subcommand
+    # itself and position 2 is the actual session-id slot.
+    _arguments \
+      '(-h --help)'{-h,--help}'[Display help for command]' \
+      ':cmd:' \
+      ':session:_claude_background_session_ids'
+    return
+    ;;
+  respawn)
+    _arguments \
+      '(--all)--all[Restart every stopped session]' \
+      '(-h --help)'{-h,--help}'[Display help for command]' \
+      ':cmd:' \
+      '(--all):session:_claude_background_session_ids'
     return
     ;;
   auth)
@@ -604,5 +707,5 @@ _arguments -s \
   '--verbose[Override verbose mode setting from config]' \
   '(-v --version)'{-v,--version}'[Output the version number]' \
   '(-w --worktree)'{-w,--worktree}'[Create a new git worktree for this session (optionally specify a name)]::name:' \
-  '1:command:(agents auth auto-mode doctor install mcp plugin plugins project remote-control setup-token ultrareview update upgrade)' \
+  '1:command:(agents attach auth auto-mode doctor install kill logs mcp plugin plugins project remote-control respawn rm setup-token stop ultrareview update upgrade)' \
   '*:prompt:'

--- a/scripts/tests/test-background-session-ids.sh
+++ b/scripts/tests/test-background-session-ids.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+#
+# Coverage for the _claude_background_session_ids completer used by the
+# background-session subcommands (`claude attach|logs|stop|kill|respawn|rm`).
+#
+# Fixture: builds ~/.claude/daemon/roster.json and ~/.claude/jobs/<id>/state.json
+# under a fake HOME, then asserts:
+#   1. Ids from roster.json appear in the completion list.
+#   2. The label is enriched with the name + state pulled from state.json.
+#   3. When roster.json is missing, the directory-scan fallback still works.
+#   4. Each background-session subcommand triggers the completer.
+
+set -e
+TEST_NAME=test-background-session-ids
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
+
+require_common_deps
+require_dep jq
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+# Build a roster + state files for two background sessions.
+build_roster_fixture() {
+    local home="$1"
+    local daemon_dir="$home/.claude/daemon"
+    local jobs_dir="$home/.claude/jobs"
+    mkdir -p "$daemon_dir" "$jobs_dir/7c5dcf5d" "$jobs_dir/9a1b2c3d"
+
+    cat > "$daemon_dir/roster.json" <<'JSON'
+{
+  "sessions": [
+    {"id": "7c5dcf5d"},
+    {"id": "9a1b2c3d"}
+  ]
+}
+JSON
+
+    cat > "$jobs_dir/7c5dcf5d/state.json" <<'JSON'
+{"name": "investigate flaky test", "state": "working"}
+JSON
+
+    cat > "$jobs_dir/9a1b2c3d/state.json" <<'JSON'
+{"name": "address PR review", "state": "needs_input"}
+JSON
+}
+
+# Build only state.json dirs (no roster) — exercises the directory-scan
+# fallback path used when the supervisor isn't running. Two entries are
+# needed so the completion menu actually renders; with a single match zsh
+# auto-inserts it without printing the description.
+build_jobs_only_fixture() {
+    local home="$1"
+    local jobs_dir="$home/.claude/jobs"
+    mkdir -p "$jobs_dir/deadbeef" "$jobs_dir/cafef00d"
+    cat > "$jobs_dir/deadbeef/state.json" <<'JSON'
+{"name": "orphan session", "state": "stopped"}
+JSON
+    cat > "$jobs_dir/cafef00d/state.json" <<'JSON'
+{"name": "second orphan", "state": "stopped"}
+JSON
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: roster-driven completion with enriched labels
+# ---------------------------------------------------------------------------
+home=$(make_test_home)
+trap 'rm -rf "$home"' EXIT
+build_roster_fixture "$home"
+
+work_dir="$home/work"
+mkdir -p "$work_dir"
+
+log "case 1: roster ids + state.json labels surface for 'claude attach'"
+output=$(run_completion "$home" "$work_dir" 'claude attach \t')
+assert_no_completion_errors "$output"
+assert_contains "7c5dcf5d" "$output" "first roster id"
+assert_contains "9a1b2c3d" "$output" "second roster id"
+assert_contains "investigate flaky test" "$output" "first session name from state.json"
+assert_contains "address PR review" "$output" "second session name from state.json"
+assert_contains "working" "$output" "first session state"
+assert_contains "needs_input" "$output" "second session state"
+
+# ---------------------------------------------------------------------------
+# Test 2: each background-session subcommand wires up the completer
+# ---------------------------------------------------------------------------
+for cmd in logs stop kill rm respawn; do
+    log "case 2.$cmd: 'claude $cmd' offers background session ids"
+    output=$(run_completion "$home" "$work_dir" "claude $cmd \\t")
+    assert_no_completion_errors "$output"
+    assert_contains "7c5dcf5d" "$output" "$cmd offers roster id"
+done
+
+# ---------------------------------------------------------------------------
+# Test 3: respawn --all is a valid completion alternative
+# ---------------------------------------------------------------------------
+log "case 3: 'claude respawn --' includes --all"
+output=$(run_completion "$home" "$work_dir" 'claude respawn --\t')
+assert_no_completion_errors "$output"
+assert_contains -- "--all" "$output" "respawn --all flag"
+
+# ---------------------------------------------------------------------------
+# Test 4: jobs/ directory-scan fallback when roster.json is missing
+# ---------------------------------------------------------------------------
+rm -rf "$home/.claude"
+build_jobs_only_fixture "$home"
+
+log "case 4: fallback scans ~/.claude/jobs when roster.json is absent"
+output=$(run_completion "$home" "$work_dir" 'claude attach \t')
+assert_no_completion_errors "$output"
+assert_contains "deadbeef" "$output" "fallback-discovered id"
+assert_contains "cafef00d" "$output" "second fallback-discovered id"
+assert_contains "orphan session" "$output" "fallback id picks up name from state.json"
+
+# ---------------------------------------------------------------------------
+# Test 5: new top-level commands are listed at the command position
+# ---------------------------------------------------------------------------
+log "case 5: 'claude <TAB>' lists the new background-session subcommands"
+output=$(run_completion "$home" "$work_dir" 'claude \t')
+assert_no_completion_errors "$output"
+for cmd in attach logs stop kill respawn rm; do
+    assert_contains "$cmd" "$output" "top-level command '$cmd'"
+done
+
+pass "background session id auto-suggestion OK"


### PR DESCRIPTION
## Summary

Agent view (Claude v2.1.139+) added a set of shell commands for managing background sessions that were missing from the completion script:

| Command | Purpose |
| :--- | :--- |
| `claude agents` | Open agent view |
| `claude attach <id>` | Attach to a session in this terminal |
| `claude logs <id>` | Print the session's recent output |
| `claude stop <id>` (also `claude kill`) | Stop a session |
| `claude respawn <id>` / `--all` | Restart a stopped session |
| `claude rm <id>` | Remove a session from the list |

Changes:

- Add `attach`, `logs`, `stop`, `kill`, `respawn`, `rm` to the top-level command list, the `known_commands` dispatcher, and the fallback `_arguments` command list. Update the `agents` description to reflect agent view.
- New `_claude_background_session_ids` completer reads `~/.claude/daemon/roster.json` (honors `CLAUDE_CONFIG_DIR`) for the live session list, then pulls the display name and state from each `~/.claude/jobs/<id>/state.json` so the completion menu shows e.g. `7c5dcf5d [working] investigate flaky test` rather than just opaque short ids.
- Falls back to scanning `~/.claude/jobs/*/state.json` when `roster.json` is missing or empty (e.g. supervisor not running but state still on disk). Parses defensively across plausible roster schemas and state.json field names since neither is formally documented.
- New `test-background-session-ids.sh` covering: roster-driven completion with enriched labels, every new subcommand wiring up the completer, `respawn --all` flag, jobs-directory fallback, and the new top-level commands appearing in the command list.

## Test plan

- [x] `./scripts/verify-completions.sh` — all 5 tests pass (syntax, global flags, mcp, session-ids, background-session-ids)
- [x] Verify on a real machine with active background sessions that `claude attach <TAB>` lists running sessions with names

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATdS4tmncFeD2RWDgDuQnm)_