### PR TITLE
Match /resume picker format for session-id completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the zsh-claudecode-completion plugin are documented here.
 
+## Unreleased
+
+### Changed
+- `claude -r <TAB>` / `claude --resume <TAB>` now labels sessions the same way the in-CLI `/resume` picker does: relative time, branch, file size, short id, and the session title — e.g. `1 day ago · main · 2.5MB - 4bd38c17: refactor-auth-flow`. The completer now reads, in priority order: `/rename`-set `customTitle`, auto-generated `aiTitle`, `sessions-index.json` `summary`, inline JSONL summary, the first non-command user prompt, and finally the slash command name (e.g. `/exit`) so command-only sessions still appear instead of being silently dropped.
+
 ## [2.1.141] - 2026-05-14
 
 ### Added

--- a/_claude
+++ b/_claude
@@ -41,106 +41,183 @@ _claude_session_ids() {
   # disables the cap for users who want the old behavior.
   local max_sessions=${CLAUDE_COMPLETION_SESSION_LIMIT:-20}
 
-  # Two-pass enumeration. Pass 1 collects cheap candidates keyed by an
-  # ISO-ish timestamp; pass 2 resolves branch/message only for the top N.
-  # Candidate line format:
-  #   "<sortkey>\t<uuid>\tindex\t<branch>\t<summary>"  (already resolved)
-  #   "<sortkey>\t<uuid>\tjsonl"                      (resolve in pass 2)
-  local -a candidates
-  local -A indexed
-
-  # Indexed sessions — one jq call gives us everything cheaply, so keep
-  # branch/summary inline and skip pass 2 for these.
+  # Pull branch + summary from sessions-index.json, keyed by sessionId.
+  # `.summary` here is the same human-readable title `/resume` displays
+  # (e.g. "refactor-auth-flow"); we prefer it over the first
+  # user prompt for indexed sessions, falling back to the JSONL when the
+  # session isn't indexed yet.
+  local -A index_summary index_branch
   if [[ -f "$index_file" ]]; then
-    while IFS=$'\t' read -r modified id branch summary; do
-      [[ -z "$id" ]] && continue
-      indexed[$id]=1
-      candidates+=("${modified}"$'\t'"${id}"$'\tindex\t'"${branch}"$'\t'"${summary}")
-    done < <(jq -rs '[.[].entries[]] | .[] | [.modified, .sessionId, (.gitBranch // "?"), (.summary // .firstPrompt[:60] // "")] | @tsv' "$index_file" 2>/dev/null)
+    local _iid _ibranch _isummary
+    while IFS=$'\t' read -r _iid _ibranch _isummary; do
+      [[ -z "$_iid" ]] && continue
+      index_summary[$_iid]="$_isummary"
+      index_branch[$_iid]="$_ibranch"
+    done < <(jq -rs '[.[].entries[]] | .[] | [.sessionId, (.gitBranch // "?"), (.summary // "")] | @tsv' "$index_file" 2>/dev/null)
   fi
 
-  # Unindexed JSONL files — just mtime+uuid here; the expensive head|jq
-  # parse is deferred until we know the candidate survived the cap. Use
-  # zsh parameter expansion (`${f:t:r}`) and a single batched `zstat` call
-  # to avoid forking a subshell per file: projects with thousands of
-  # sessions would otherwise spend many seconds just naming the files.
-  # `zstat` (zsh/stat module) is used instead of the external `stat` because
-  # the GNU and BSD versions disagree on flags — GNU `stat -f` means
-  # filesystem-status, not "format", so the BSD invocation produced garbage
-  # paths on Linux.
+  # Single batched `zstat` for both mtime (epoch seconds) and size (bytes)
+  # on every jsonl file. Using one stat source for all sessions keeps the
+  # sort key uniform and gives us the size that `/resume` shows alongside
+  # the relative-time label. `zstat` is preferred over external `stat`
+  # because GNU/BSD `stat` flags disagree (GNU `stat -f` means
+  # filesystem-status, not "format"), so the BSD invocation produced
+  # garbage paths on Linux.
   #
   # Note: all locals used below are declared once here, up-front. zsh
   # prints the current value of a variable when `local`/`typeset` is
   # applied to it a second time in the same scope (treats it like
-  # `typeset -p`), so pass 2 must *not* redeclare these.
-  local -a jsonl_files mtimes top
-  local line iso_mtime filepath uuid sortkey src branch msg datestr info
-  local count=0 headroom idx
+  # `typeset -p`), so the second pass must *not* redeclare these.
+  local -a jsonl_files mtimes sizes candidates top
+  local line filepath uuid mtime size title branch info reltime sizestr
+  local _jb _jcustom _jai _jsum _jprompt _jcmd
+  local count=0 headroom idx d h m days weeks months years kb mb gb now
 
   jsonl_files=( "$project_dir"/*.jsonl(N) )
-  if (( ${#jsonl_files} > 0 )); then
-    zmodload -F zsh/stat b:zstat 2>/dev/null
-    zstat -A mtimes -F '%Y-%m-%dT%H:%M:%S' +mtime "${jsonl_files[@]}" 2>/dev/null
-    idx=1
-    for filepath in "${jsonl_files[@]}"; do
-      iso_mtime="${mtimes[$idx]}"
-      (( idx++ ))
-      uuid="${filepath:t:r}"
-      [[ -n "${indexed[$uuid]}" ]] && continue
-      [[ -z "$iso_mtime" ]] && continue
-      candidates+=("${iso_mtime}"$'\t'"${uuid}"$'\tjsonl')
-    done
+  (( ${#jsonl_files} == 0 )) && return 1
+
+  zmodload -F zsh/stat b:zstat 2>/dev/null
+  zstat -A mtimes +mtime "${jsonl_files[@]}" 2>/dev/null
+  zstat -A sizes  +size  "${jsonl_files[@]}" 2>/dev/null
+
+  idx=1
+  for filepath in "${jsonl_files[@]}"; do
+    mtime="${mtimes[$idx]}"
+    size="${sizes[$idx]:-0}"
+    (( idx++ ))
+    uuid="${filepath:t:r}"
+    [[ -z "$mtime" ]] && continue
+    candidates+=("${mtime}"$'\t'"${uuid}"$'\t'"${size}"$'\t'"${filepath}")
+  done
+
+  # Sort newest first (numeric epoch), then cap. Headroom covers JSONL
+  # files filtered out in pass 2 (only meta / <command-*> entries) so the
+  # list doesn't come up short.
+  if (( ${#candidates} > 0 )); then
+    if (( max_sessions > 0 )); then
+      headroom=$(( max_sessions * 2 + 5 ))
+      while IFS= read -r line; do top+=("$line"); done \
+        < <(printf '%s\n' "${candidates[@]}" | sort -nr | head -n $headroom)
+    else
+      while IFS= read -r line; do top+=("$line"); done \
+        < <(printf '%s\n' "${candidates[@]}" | sort -nr)
+    fi
   fi
 
-  # Sort descending by sortkey, then cap. Use a small headroom so JSONL
-  # files that get filtered out in pass 2 (only meta / <command-*>
-  # entries) don't leave the list short.
-  if (( max_sessions > 0 )); then
-    headroom=$(( max_sessions * 2 + 5 ))
-    while IFS= read -r line; do top+=("$line"); done \
-      < <(printf '%s\n' "${candidates[@]}" | sort -r | head -n $headroom)
-  else
-    while IFS= read -r line; do top+=("$line"); done \
-      < <(printf '%s\n' "${candidates[@]}" | sort -r)
-  fi
+  zmodload -F zsh/datetime p:EPOCHSECONDS 2>/dev/null
+  now=${EPOCHSECONDS:-$(date +%s)}
 
-  # Pass 2: for each surviving candidate, resolve branch/message if needed
-  # and build the display rows. Newest-first order is preserved by sort -r
-  # above and by `-o nosort` on the compadd call below. (Plain `-V` alone
-  # isn't enough in some zsh setups; `-o nosort` is the canonical zsh API
-  # that reliably disables the alphabetical re-sort.)
+  # Pass 2: resolve title/branch (from index when possible, else parse the
+  # JSONL), compute the same "1 day ago · main · 2.5MB" trio `/resume`
+  # displays, and build the label. Newest-first order is preserved by
+  # `sort -nr` above and by `-o nosort` on the compadd call below.
   for line in "${top[@]}"; do
     (( max_sessions > 0 && count >= max_sessions )) && break
-    IFS=$'\t' read -r sortkey uuid src branch msg <<< "$line"
-    datestr="${sortkey:0:10}"
-    if [[ "$src" == "jsonl" ]]; then
-      # Extract branch + first real user prompt in one jq call.
-      # Skip isMeta wrappers and <command-*> / <local-command-*> messages.
-      # Emits nothing when no resumable user prompt exists, so files
-      # containing only file-history-snapshots, hook progress, or
-      # <command-*>/meta entries are filtered out — `claude --resume`
-      # rejects those with "No conversation found".
-      info=$(head -100 "$project_dir/$uuid.jsonl" | jq -rs '
-        [.[] | select(.type=="user")] as $users |
-        ([
-          $users[]
-          | select((.isMeta // false) != true and .message.content != null)
-          | .message.content
-          | if type=="array" then .[0].text else . end
-          | select(. != null)
-          | select(test("^\\s*<(command|local-command)") | not)
-        ] | first) as $msg |
-        if $msg == null then empty else
-          ($users[0].gitBranch // "?") as $branch |
-          "\($branch)\t\($msg | gsub("\n"; " ") | .[0:60])"
-        end
-      ' 2>/dev/null)
-      [[ -z "$info" ]] && continue
-      branch="${info%%$'\t'*}"
-      msg="${info#*$'\t'}"
+    IFS=$'\t' read -r mtime uuid size filepath <<< "$line"
+
+    branch="${index_branch[$uuid]:-?}"
+    # Parse the JSONL for live title signals — `/rename`-set custom titles
+    # (type: custom-title) and auto-generated `ai-title` records both live
+    # there and outrank any frozen `summary` recorded in sessions-index.json.
+    # We always check, so renaming a session immediately reflects in the
+    # completer. Both record types get appended throughout the session, so
+    # reading `head -100; tail -50` catches them without parsing multi-MB
+    # files. Fields are emitted one per line (with newlines stripped) so
+    # zsh's `read` doesn't collide with tab-collapsing IFS rules when
+    # intermediate values are empty.
+    _jb=""; _jcustom=""; _jai=""; _jsum=""; _jprompt=""; _jcmd=""
+    {
+      IFS= read -r _jb
+      IFS= read -r _jcustom
+      IFS= read -r _jai
+      IFS= read -r _jsum
+      IFS= read -r _jprompt
+      IFS= read -r _jcmd
+    } < <( { head -100 "$filepath"; tail -50 "$filepath"; } 2>/dev/null | jq -rs '
+      [.[] | select(.type=="user")] as $users |
+      ([.[] | select(.type=="custom-title") | .customTitle] | last // "") as $custom |
+      ([.[] | select(.type=="ai-title")     | .aiTitle]     | last // "") as $ai     |
+      ([.[] | select(.type=="summary")      | .summary]     | first // "") as $sum  |
+      ([
+        $users[]
+        | select((.isMeta // false) != true and .message.content != null)
+        | .message.content
+        | if type=="array" then .[0].text else . end
+        | select(. != null)
+        | select(test("^\\s*<(command|local-command)") | not)
+      ] | first // "") as $prompt |
+      # Command-only sessions (e.g. a quick `/exit`) still show in `/resume`
+      # labelled by the slash command itself; extract that from the
+      # <command-name>...</command-name> tag so they surface here too.
+      ([
+        $users[]
+        | (.message.content | if type=="array" then .[0].text else . end)
+        | select(. != null and test("<command-name>"))
+        | capture("<command-name>(?<c>[^<]+)</command-name>") | .c
+      ] | first // "") as $cmd |
+      ($users[0].gitBranch // "") as $br |
+      [$br, $custom, $ai, $sum, $prompt, $cmd][]
+      | gsub("\n"; " ")
+    ' 2>/dev/null )
+    [[ -n "$_jb" ]] && branch="$_jb"
+    # Priority: /rename customTitle → aiTitle → index summary →
+    # inline summary record → first user prompt → first slash command.
+    if   [[ -n "$_jcustom" ]]; then title="$_jcustom"
+    elif [[ -n "$_jai"     ]]; then title="$_jai"
+    elif [[ -n "${index_summary[$uuid]}" ]]; then title="${index_summary[$uuid]}"
+    elif [[ -n "$_jsum"    ]]; then title="$_jsum"
+    elif [[ -n "$_jprompt" ]]; then title="$_jprompt"
+    elif [[ -n "$_jcmd"    ]]; then title="$_jcmd"
+    else title=""
     fi
+    [[ -z "$title" ]] && continue
+    # Trim/normalize for one-line display.
+    title="${title//$'\n'/ }"
+    (( ${#title} > 80 )) && title="${title:0:80}"
+
+    # Relative time — same buckets `/resume` uses.
+    d=$(( now - mtime ))
+    (( d < 0 )) && d=0
+    if (( d < 60 )); then
+      (( d == 1 )) && reltime="1 second ago" || reltime="${d} seconds ago"
+    elif (( d < 3600 )); then
+      m=$(( d / 60 ))
+      (( m == 1 )) && reltime="1 minute ago" || reltime="${m} minutes ago"
+    elif (( d < 86400 )); then
+      h=$(( d / 3600 ))
+      (( h == 1 )) && reltime="1 hour ago" || reltime="${h} hours ago"
+    elif (( d < 604800 )); then
+      days=$(( d / 86400 ))
+      (( days == 1 )) && reltime="1 day ago" || reltime="${days} days ago"
+    elif (( d < 2592000 )); then
+      weeks=$(( d / 604800 ))
+      (( weeks == 1 )) && reltime="1 week ago" || reltime="${weeks} weeks ago"
+    elif (( d < 31536000 )); then
+      months=$(( d / 2592000 ))
+      (( months == 1 )) && reltime="1 month ago" || reltime="${months} months ago"
+    else
+      years=$(( d / 31536000 ))
+      (( years == 1 )) && reltime="1 year ago" || reltime="${years} years ago"
+    fi
+
+    # Human-readable size, one decimal place. Avoids forking awk/bc; zsh
+    # integer arithmetic keeps the pass-2 loop hot for projects with
+    # hundreds of sessions.
+    if (( size < 1024 )); then
+      sizestr="${size}B"
+    elif (( size < 1048576 )); then
+      kb=$(( size * 10 / 1024 ))
+      (( kb % 10 == 0 )) && sizestr="$((kb/10))KB" || sizestr="$((kb/10)).$((kb%10))KB"
+    elif (( size < 1073741824 )); then
+      mb=$(( size * 10 / 1048576 ))
+      (( mb % 10 == 0 )) && sizestr="$((mb/10))MB" || sizestr="$((mb/10)).$((mb%10))MB"
+    else
+      gb=$(( size * 10 / 1073741824 ))
+      (( gb % 10 == 0 )) && sizestr="$((gb/10))GB" || sizestr="$((gb/10)).$((gb%10))GB"
+    fi
+
     ids+=("$uuid")
-    labels+=("${datestr} ${uuid:0:8}- [${branch}] ${msg}")
+    labels+=("${reltime} · ${branch} · ${sizestr} - ${uuid:0:8}: ${title}")
     (( count++ ))
   done
 

--- a/scripts/tests/test-session-ids.sh
+++ b/scripts/tests/test-session-ids.sh
@@ -43,13 +43,22 @@ build_fixture() {
     fi
     mkdir -p "$proj_dir"
 
-    # An indexed session — newest, so it sorts first.
+    # An indexed session — newest, so it sorts first. Real indexed sessions
+    # always have a backing JSONL on disk (the index points at it via
+    # fullPath); make the fixture mirror that so the indexed-summary path
+    # is what gets tested, not a missing-file edge case.
+    local uuid_indexed="aaaaaaaa-1111-2222-3333-aaaaaaaaaaaa"
+    cat > "$proj_dir/$uuid_indexed.jsonl" <<JSONL
+{"type":"user","gitBranch":"main","message":{"content":"indexed jsonl prompt (should be hidden by summary)"}}
+JSONL
+    touch -d "2026-05-09T12:00:00" "$proj_dir/$uuid_indexed.jsonl"
+
     cat > "$proj_dir/sessions-index.json" <<JSON
 {
   "originalPath": "$work_dir",
   "entries": [
     {
-      "sessionId": "aaaaaaaa-1111-2222-3333-aaaaaaaaaaaa",
+      "sessionId": "$uuid_indexed",
       "modified": "2026-05-09T12:00:00",
       "gitBranch": "main",
       "summary": "indexed session label"
@@ -67,8 +76,39 @@ JSONL
     # ISO-8601 with T separator — BSD touch on macOS rejects the space form.
     touch -d "2026-05-08T10:00:00" "$proj_dir/$uuid_jsonl.jsonl"
 
-    # A JSONL session that contains ONLY a <command-*> wrapped prompt — the
-    # completer should filter this out (claude --resume rejects it).
+    # A JSONL session whose label should come from a trailing `ai-title`
+    # record (what `/resume` displays for recent, not-yet-indexed
+    # sessions). The first user prompt is intentionally generic so the
+    # assertion only passes if the ai-title path is actually taken.
+    local uuid_aititle="dddddddd-1111-2222-3333-dddddddddddd"
+    cat > "$proj_dir/$uuid_aititle.jsonl" <<JSONL
+{"type":"user","gitBranch":"main","message":{"content":"hello there"}}
+{"type":"ai-title","aiTitle":"refactor-auth-flow","sessionId":"$uuid_aititle"}
+JSONL
+    touch -d "2026-05-08T11:00:00" "$proj_dir/$uuid_aititle.jsonl"
+
+    # A JSONL session with a `/rename`-set custom title — outranks
+    # ai-title, summary, and the prompt.
+    local uuid_custom="eeeeeeee-1111-2222-3333-eeeeeeeeeeee"
+    cat > "$proj_dir/$uuid_custom.jsonl" <<JSONL
+{"type":"user","gitBranch":"main","message":{"content":"some prompt"}}
+{"type":"ai-title","aiTitle":"auto-generated-title","sessionId":"$uuid_custom"}
+{"type":"custom-title","customTitle":"my-renamed-session","sessionId":"$uuid_custom"}
+JSONL
+    touch -d "2026-05-08T13:00:00" "$proj_dir/$uuid_custom.jsonl"
+
+    # A JSONL session whose only user content is wrapped <command-name> —
+    # the completer should pull "/exit" out of the tag instead of dropping
+    # the session entirely (this mirrors what `/resume` shows).
+    local uuid_cmdname="ffffffff-1111-2222-3333-ffffffffffff"
+    cat > "$proj_dir/$uuid_cmdname.jsonl" <<JSONL
+{"type":"user","gitBranch":"main","message":{"content":"<command-name>/exit</command-name>\n<command-message>exit</command-message>"}}
+JSONL
+    touch -d "2026-05-08T09:00:00" "$proj_dir/$uuid_cmdname.jsonl"
+
+    # A JSONL session that contains ONLY a <command-stdout>/<local-command-*>
+    # wrapper with no <command-name> — the completer should filter this
+    # out (claude --resume rejects it).
     local uuid_filtered="cccccccc-1111-2222-3333-cccccccccccc"
     cat > "$proj_dir/$uuid_filtered.jsonl" <<JSONL
 {"type":"user","gitBranch":"main","message":{"content":"<command-stdout>boring</command-stdout>"}}
@@ -97,8 +137,23 @@ assert_contains "main"     "$output" "indexed session branch"
 assert_contains "bbbbbbbb" "$output" "jsonl session UUID prefix"
 assert_contains "feature"  "$output" "jsonl session branch"
 assert_contains "jsonl session prompt" "$output" "jsonl session summary"
-# Filtered <command-*> session must not show up.
+# ai-title-bearing session uses its aiTitle as the label, not the prompt.
+assert_contains "dddddddd" "$output" "ai-title session UUID prefix"
+assert_contains "refactor-auth-flow" "$output" "ai-title session label"
+assert_not_contains "hello there" "$output" "ai-title outranks first prompt"
+# /rename customTitle outranks aiTitle/summary/prompt.
+assert_contains "eeeeeeee" "$output" "custom-title session UUID prefix"
+assert_contains "my-renamed-session" "$output" "custom-title label"
+assert_not_contains "auto-generated-title" "$output" "customTitle outranks aiTitle"
+# Sessions whose only content is a <command-name> tag still appear,
+# labelled by the slash command (mirrors `/resume`).
+assert_contains "ffffffff" "$output" "command-name session UUID prefix"
+assert_contains "/exit"    "$output" "command-name label"
+# Sessions with only a <command-stdout> wrapper (no <command-name>) must
+# still be filtered out.
 assert_not_contains "cccccccc" "$output" "filtered command-only session"
+# Relative-time formatting (e.g. "1 day ago") replaces the old ISO date.
+assert_contains " ago" "$output" "relative time label present"
 
 # ---------------------------------------------------------------------------
 # Test 2: fallback via sessions-index.json originalPath


### PR DESCRIPTION
## Summary

- `claude -r <TAB>` / `claude --resume <TAB>` now labels each session the way the in-CLI `/resume` picker does: relative time, branch, file size, short id, and the actual session title — e.g. `1 day ago · main · 2.5MB - 4bd38c17: refactor-auth-flow`.
- Title source order: `/rename` `customTitle` → `aiTitle` → `sessions-index.json` summary → inline JSONL summary → first non-command user prompt → slash command name (so `/exit`-only sessions surface instead of being dropped).
- Replaced the ISO date with a relative-time string (`16 seconds ago`, `1 day ago`, `1 week ago`, …) and added file size, both pulled from a single batched `zstat` call.

## Why

The previous label was the first user prompt verbatim, not the title `/resume` actually shows. With this change the two views match — same time grain, same titles, same ordering — so picking a session by TAB feels the same as picking it in the picker. Before:

```
2026-05-04 4bd38c17- [main] Let's work on this task : https://example.com/…
```

After:

```
1 day ago · main · 2.5MB - 4bd38c17: refactor-auth-flow
```

## Implementation notes

- jq now hands six values back to the shell one-per-line rather than tab-joined. zsh's `read -r` with `IFS=$'\t'` collapses consecutive tabs (tab is an IFS-whitespace char), which silently shifted later fields into earlier slots when intermediate values were empty — that bug was caught by the test suite, not at runtime.
- `head -100 ; tail -50` is enough to catch both head-of-file `summary` records and trailing `ai-title` / `custom-title` records without parsing multi-MB JSONL files.

## Test plan

- [x] `./scripts/verify-completions.sh` — all 6 suites pass (5 existing + the new hidden-flags suite from main), including new assertions for `customTitle` priority, `aiTitle` priority, `/exit` command-name extraction, and the relative-time label.
- [x] Manual smoke against a real project directory: top entries match what `/resume` shows (including `/exit` rows and a `/rename`-set custom title).