### PR TITLE
fix(agents): restore completion for `claude agents` and other flag-only subcommands

### DIFF
--- a/_claude
+++ b/_claude
@@ -410,7 +410,12 @@ local sub1=$(( subcmd_pos + 1 ))
 
 case $subcmd in
   agents)
+    # `_arguments` here is invoked as `claude`'s completer and counts
+    # positionals from $words[2], so the leading ':cmd:' placeholder is
+    # required to absorb the `agents` subcommand word — without it, the
+    # flag specs never engage and `claude agents <TAB>` produces nothing.
     _arguments -s \
+      ':cmd:' \
       '*--add-dir[Additional directory to allow tool access to in dispatched sessions (repeatable)]:directory:_files -/' \
       '--allow-dangerously-skip-permissions[Make bypass-permissions mode available to dispatched sessions without defaulting to it]' \
       '--cwd[Show only background sessions started under path]:path:_files -/' \
@@ -707,6 +712,7 @@ case $subcmd in
     _arguments \
       '--force[Force installation even if already installed]' \
       '(-h --help)'{-h,--help}'[Display help]' \
+      ':cmd:' \
       ':target:(stable latest)'
     return
     ;;
@@ -715,7 +721,8 @@ case $subcmd in
       '(-h --help)'{-h,--help}'[Display help]' \
       '--sandbox[Enable sandboxing for filesystem and network isolation]' \
       '--no-sandbox[Disable sandboxing]' \
-      '--verbose[Show detailed connection and session logs]'
+      '--verbose[Show detailed connection and session logs]' \
+      ':cmd:'
     return
     ;;
   ultrareview)
@@ -723,12 +730,14 @@ case $subcmd in
       '(-h --help)'{-h,--help}'[Display help]' \
       '--json[Print the raw bugs.json payload instead of formatted findings]' \
       '--timeout[Maximum minutes to wait for the review to finish (default: 30)]:minutes:' \
+      ':cmd:' \
       '::target:'
     return
     ;;
   setup-token|doctor|update|upgrade)
     _arguments \
-      '(-h --help)'{-h,--help}'[Display help]'
+      '(-h --help)'{-h,--help}'[Display help]' \
+      ':cmd:'
     return
     ;;
 esac

--- a/scripts/tests/test-agents-subcommand.sh
+++ b/scripts/tests/test-agents-subcommand.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Regression test for `claude agents` completion. The `agents` subcommand
+# accepts only flags (no positional args), so an earlier `_arguments` block
+# omitted the `:cmd:` placeholder that absorbs the subcommand word. When
+# `_arguments` is invoked here as `claude`'s top-level completer, positionals
+# are counted from $words[2] — without `:cmd:` the `agents` word fell through
+# unmatched and `claude agents <TAB>` / `claude agents --<TAB>` produced no
+# completions at all.
+
+set -e
+TEST_NAME=test-agents-subcommand
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
+
+require_common_deps
+
+home=$(make_test_home)
+trap 'rm -rf "$home"' EXIT
+
+log "case 1: 'claude agents <TAB>' completes without error"
+output=$(run_completion "$home" "$home" 'claude agents \t')
+assert_no_completion_errors "$output"
+
+log "case 2: 'claude agents --<TAB>' lists agents-specific flags"
+output=$(run_completion "$home" "$home" 'claude agents --\t')
+assert_no_completion_errors "$output"
+for flag in --add-dir --cwd --effort --json --model --permission-mode \
+            --plugin-dir --settings --strict-mcp-config; do
+    assert_contains -- "$flag" "$output" "agents flag '$flag'"
+done
+
+log "case 3: 'claude agents --permission-mode <TAB>' offers mode values"
+output=$(run_completion "$home" "$home" 'claude agents --permission-mode \t')
+assert_no_completion_errors "$output"
+for mode in acceptEdits bypassPermissions default plan; do
+    assert_contains "$mode" "$output" "permission-mode value '$mode'"
+done
+
+pass "agents subcommand completion OK"


### PR DESCRIPTION
## Summary

`claude agents <TAB>` (and `claude agents --<TAB>`) produced no completions. Several other subcommands were silently affected by the same root cause.

## Root cause

`_arguments` is invoked here as `claude`'s top-level completer, so it counts positionals from `$words[2]`. The `agents` block (and friends) listed only flag specs — there was no `:cmd:` placeholder to absorb the subcommand word, so `_arguments` never engaged and offered nothing.

The existing `attach|logs|stop|kill|rm` block already documents this pattern:

```zsh
# The leading ':cmd:' placeholder accounts for the subcommand word
# already in $words — _arguments here is invoked as `claude`'s completer
# and counts positionals from $words[2], so position 1 = the subcommand
# itself and position 2 is the actual session-id slot.
```

## Fix

Add a `:cmd:` placeholder to the affected blocks:

- `agents` — completion was fully broken
- `doctor`, `setup-token`, `update`, `upgrade` — only `--help`, broken too
- `remote-control` — flags-only, broken
- `install` — positional `:target:(stable|latest)` was being consumed by the `install` word itself, so `claude install <TAB>` showed nothing
- `ultrareview` — same shape

## Test

Added `scripts/tests/test-agents-subcommand.sh` covering:
1. `claude agents <TAB>` — no errors
2. `claude agents --<TAB>` — lists agent-specific flags (`--add-dir`, `--cwd`, `--effort`, `--json`, `--model`, `--permission-mode`, `--plugin-dir`, `--settings`, `--strict-mcp-config`)
3. `claude agents --permission-mode <TAB>` — offers `acceptEdits`, `bypassPermissions`, `default`, `plan`

## Test plan

- [x] New `test-agents-subcommand` passes
- [x] Full suite (`scripts/verify-completions.sh`) — 7/7 pass
- [x] Manual: `claude agents --<TAB>`, `claude doctor --<TAB>`, `claude install <TAB>`, `claude remote-control --<TAB>` all show expected completions

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjsXbM4vwjUiiBL1NqmNNi)_