### PR TITLE
feat(daemon): add completion for hidden `claude daemon` command

### DIFF
--- a/.claude/commands/update-completions.md
+++ b/.claude/commands/update-completions.md
@@ -44,14 +44,29 @@ Some Claude CLI commands are **hidden** — they work but are not listed in `cla
 | Command | Help command | Description |
 |---------|-------------|-------------|
 | `remote-control` | `claude remote-control --help` | Connect local environment to claude.ai/code |
+| `daemon` | `claude daemon --help` | Manage the background-session supervisor (`run`, `status`, `logs`, `uninstall`, `stop`) |
 
 For each hidden command:
 1. Run its `--help` to get flags and description
 2. Also check the official docs at `https://code.claude.com/docs/en/<command-name>.md` for any flags not shown in `--help` (e.g., `remote-control` has `--sandbox`, `--no-sandbox`, `--verbose` documented but not in `--help`)
 3. Include the command in both the `commands` array and the `case` statement, same as visible commands
 4. Include it in the `'1:command:(...)'` list at the bottom
+5. Also add it to the `known_commands` array used by the subcommand-position scanner; otherwise a hidden parent like `daemon` won't be detected and its subcommands (e.g. `daemon stop`) will route to the wrong top-level case
 
 **Maintaining this list**: When you discover new hidden commands (e.g., a command referenced in docs or changelogs but missing from `--help`), add them to this table so future updates preserve them.
+
+### Do NOT remove a command just because it's missing from `claude --help`
+
+The completion script intentionally lists commands that are not in `claude --help` (see the Hidden Commands table above). Before deleting any command from `_claude` because you can't find it in the help output, **verify it is actually gone** by invoking it:
+
+```bash
+claude <command> --help 2>&1
+```
+
+- If you get a real usage block → the command exists, keep it (and add it to the Hidden Commands table above if it's missing).
+- Only an `unknown command` / `error: unknown command '<name>'` style error means it has truly been removed.
+
+When in doubt, probe the CLI rather than dropping the entry. Treat every command currently in `_claude` as "verify before remove."
 
 ### Hidden Flags
 

--- a/_claude
+++ b/_claude
@@ -318,6 +318,7 @@ commands=(
   'attach:Attach to a background session in this terminal'
   'auth:Manage authentication'
   'auto-mode:Inspect auto mode classifier configuration'
+  'daemon:Manage the background session supervisor'
   'doctor:Check the health of your Claude Code auto-updater'
   'install:Install Claude Code native build. Use [target] to specify version (stable, latest, or specific version)'
   'kill:Stop a background session (alias for stop)'
@@ -390,7 +391,7 @@ marketplace_commands=(
 # This handles cases where flags appear before the subcommand (e.g., alias claude='claude --flag').
 local subcmd_pos=0
 local subcmd=""
-local -a known_commands=(agents attach auth auto-mode doctor install kill logs mcp plugin plugins project remote-control respawn rm setup-token stop ultrareview update upgrade)
+local -a known_commands=(agents attach auth auto-mode daemon doctor install kill logs mcp plugin plugins project remote-control respawn rm setup-token stop ultrareview update upgrade)
 local i
 for (( i=2; i <= ${#words}; i++ )); do
   # Skip flags and their values
@@ -680,6 +681,47 @@ case $subcmd in
     fi
     return
     ;;
+  daemon)
+    if (( CURRENT == sub1 )); then
+      local -a daemon_commands
+      daemon_commands=(
+        'run:Run the supervisor in the foreground (default when piped)'
+        'status:Show daemon pid, version, uptime'
+        'logs:Tail the daemon log (Ctrl-C to stop)'
+        'uninstall:Remove the background service (launchctl/systemd)'
+        'stop:Shut down the supervisor and terminate background sessions'
+      )
+      _describe 'daemon command' daemon_commands
+    else
+      case $words[$sub1] in
+        run)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '--json-path[Config file (default: ~/.claude/daemon.json)]:path:_files' \
+            '--log-file[Log file (default: ~/.claude/daemon.log)]:path:_files' \
+            '::json-path:_files'
+          ;;
+        stop)
+          _arguments \
+            '--any[Also stop a transient (non-service) daemon]' \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '--json-path[Config file (default: ~/.claude/daemon.json)]:path:_files' \
+            '--keep-workers[Leave detached sessions running]' \
+            '--log-file[Log file (default: ~/.claude/daemon.log)]:path:_files'
+          ;;
+        status|logs|uninstall)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '--json-path[Config file (default: ~/.claude/daemon.json)]:path:_files' \
+            '--log-file[Log file (default: ~/.claude/daemon.log)]:path:_files'
+          ;;
+        *)
+          _message 'no more arguments'
+          ;;
+      esac
+    fi
+    return
+    ;;
   auto-mode)
     if (( CURRENT == sub1 )); then
       local -a auto_mode_commands
@@ -803,5 +845,5 @@ _arguments -s \
   '--verbose[Override verbose mode setting from config]' \
   '(-v --version)'{-v,--version}'[Output the version number]' \
   '(-w --worktree)'{-w,--worktree}'[Create a new git worktree for this session (optionally specify a name)]::name:' \
-  '1:command:(agents attach auth auto-mode doctor install kill logs mcp plugin plugins project remote-control respawn rm setup-token stop ultrareview update upgrade)' \
+  '1:command:(agents attach auth auto-mode daemon doctor install kill logs mcp plugin plugins project remote-control respawn rm setup-token stop ultrareview update upgrade)' \
   '*:prompt:'

--- a/scripts/tests/test-daemon-subcommand.sh
+++ b/scripts/tests/test-daemon-subcommand.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Completion test for the hidden `claude daemon` subcommand. Verifies the
+# subcommand list (`run`, `status`, `logs`, `uninstall`, `stop`), the
+# daemon-wide options (`--json-path`, `--log-file`), and the stop-specific
+# flags (`--any`, `--keep-workers`).
+
+set -e
+TEST_NAME=test-daemon-subcommand
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
+
+require_common_deps
+
+home=$(make_test_home)
+trap 'rm -rf "$home"' EXIT
+
+log "case 1: 'claude daemon <TAB>' lists daemon subcommands"
+output=$(run_completion "$home" "$home" 'claude daemon \t')
+assert_no_completion_errors "$output"
+for cmd in run status logs uninstall stop; do
+    assert_contains "$cmd" "$output" "daemon subcommand '$cmd'"
+done
+
+log "case 2: 'claude daemon --<TAB>' offers daemon-wide options"
+output=$(run_completion "$home" "$home" 'claude daemon run --\t')
+assert_no_completion_errors "$output"
+for flag in --json-path --log-file; do
+    assert_contains -- "$flag" "$output" "daemon flag '$flag'"
+done
+
+log "case 3: 'claude daemon stop --<TAB>' includes stop-specific flags"
+output=$(run_completion "$home" "$home" 'claude daemon stop --\t')
+assert_no_completion_errors "$output"
+for flag in --any --keep-workers; do
+    assert_contains -- "$flag" "$output" "daemon stop flag '$flag'"
+done
+
+pass "daemon subcommand completion OK"


### PR DESCRIPTION
## Summary

Adds zsh completion for the hidden `claude daemon` command (the background-session supervisor).

- Subcommands: `run`, `status`, `logs`, `uninstall`, `stop`
- Shared options: `--json-path`, `--log-file`
- `stop`-specific flags: `--any`, `--keep-workers`
- `run` accepts an optional positional `json-path`

`daemon` is added to the top-level command list and to `known_commands` so `claude daemon stop` routes to the daemon dispatcher rather than the top-level background-session `stop`.

## Test plan

- [x] `./scripts/verify-completions.sh` — all 8 tests pass, including the new `test-daemon-subcommand`
- [x] `claude daemon <TAB>` lists subcommands
- [x] `claude daemon run --<TAB>` offers `--json-path` / `--log-file`
- [x] `claude daemon stop --<TAB>` includes `--any` / `--keep-workers`

https://claude.ai/code/session_01KLiYLMsP6KxJiZoBaJRcKU

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLiYLMsP6KxJiZoBaJRcKU)_